### PR TITLE
Fix clang "uninitialized variable" errors.

### DIFF
--- a/pslse/cmd.c
+++ b/pslse/cmd.c
@@ -1881,7 +1881,7 @@ void handle_caia2_cmds(struct cmd *cmd)
 		case PSL_COMMAND_XLAT_RD_P0:
 			need_a_tag = 1;
 			done_it = 0;
-			while (need_a_tag == 1)  {
+			do {
 				this_itag = rtag;
 				head = &cmd->list;
 				while (*head != NULL) {
@@ -1910,7 +1910,7 @@ void handle_caia2_cmds(struct cmd *cmd)
 					event->state = MEM_DONE;
 					break;
 					}
-			}
+			} while (need_a_tag == 1);
 
 			event->itag = this_itag;
 			event->port = 0;
@@ -1924,7 +1924,7 @@ void handle_caia2_cmds(struct cmd *cmd)
 		case PSL_COMMAND_XLAT_WR_P0:
 			need_a_tag = 1;
 			done_it = 0;
-			while (need_a_tag == 1)  {
+			do {
 				this_itag = wtag;
 				head = &cmd->list;
 				while (*head != NULL) {
@@ -1953,7 +1953,7 @@ void handle_caia2_cmds(struct cmd *cmd)
 					event->state = MEM_DONE;
 					break;
 					}
-			}
+			} while (need_a_tag == 1);
 			event->itag = this_itag;
 			event->port = 0;
 			//printf("in handle_caia2 for xlat_wr, address is 0x%016"PRIX64 "\n", event->addr);


### PR DESCRIPTION
LLVM/Clang has very paranoid checks for uninitialized variables.  The old code created errors such as:

```
pslse/cmd.c:1927:11: error: variable 'this_itag' is used uninitialized whenever 'while' loop exits because its condition is false [-Werror,-Wsometimes-uninitialized]
                        while (need_a_tag == 1)  {
                               ^~~~~~~~~~~~~~~
pslse/cmd.c:1957:18: note: uninitialized use occurs here
                        event->itag = this_itag;
                                      ^~~~~~~~~
pslse/cmd.c:1927:11: note: remove the condition if it is always true
                        while (need_a_tag == 1)  {
                               ^~~~~~~~~~~~~~~
                               1
pslse/pslse/cmd.c:1813:20: note: initialize the variable 'this_itag' to silence this warning
        uint32_t this_itag, done_it;
                          ^
                           = 0
```

The fix is to transform some while (condition) {...} loops into do {...} while (condition).